### PR TITLE
修复分享时调用gitee_aiimg生成图片出错的问题

### DIFF
--- a/core/image.py
+++ b/core/image.py
@@ -347,12 +347,18 @@ class ImageService:
                 self._aiimg_plugin_not_found = True
 
         if self._aiimg_plugin:
-            try: 
-                target_size = self._aiimg_plugin.config.get("size", "1024x1024")
-                path_obj = await self._aiimg_plugin.service.generate(prompt=prompt, size=target_size)
+            try:
+                # 从 gitee_aiimg 插件配置中读取尺寸，路径：config -> draw -> size
+                draw_conf = self._aiimg_plugin.config.get("draw", {})
+                target_size = draw_conf.get("size", "1024x1024") if isinstance(draw_conf, dict) else "1024x1024"
+                
+                # 正确的属性名是 `draw`，不是 `service`
+                path_obj = await self._aiimg_plugin.draw.generate(prompt=prompt, size=target_size)
                 return str(path_obj)
                 
-            except Exception as e: 
+            except Exception as e:
                 logger.error(f"[DailySharing] 生成图片出错: {e}")
+                import traceback
+                logger.error(traceback.format_exc())
                 
         return None


### PR DESCRIPTION
报错：[v4.12.1] [core.image:356]: [DailySharing] 生成图片出错: 'GiteeAIImage' object has no attribute 'service' 

问题出在 AstrBot/data/plugins/astrbot_plugin_daily_sharing/core/image.py 的 _call_aiimg 方法（第339-358行）： # 第351-352行的错误代码：
target_size = self._aiimg_plugin.config.get("size", "1024x1024") path_obj = await self._aiimg_plugin.service.generate(prompt=prompt, size=target_size)

这里试图访问 self._aiimg_plugin.service，但是GiteeAIImage 类没有 service 属性，正确的属性名是 draw（ImageDrawService 实例）。